### PR TITLE
feat(465): Create plugin for email notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ artifacts/
 npm-debug.log
 .DS_STORE
 .*.swp
+.nyc_output/

--- a/README.md
+++ b/README.md
@@ -8,6 +8,46 @@
 ```bash
 npm install screwdriver-notifications-email
 ```
+### Initialization
+
+The class has a variety of knobs to tweak when interacting with Email Notifications.
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| config        | Object | Configuration Object |
+| config.host | String | SMTP Host URL |
+| config.port | Number | Port to use when connecting to SMTP |
+| config.from | String | Sender email address |
+
+The interface looks for email-specific build data:
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| buildData        | Object | Build Data Object |
+| buildData.status | String | Build status update for notification |
+| buildData.settings | Object | Pluggable settings for each build |
+| buildData.settings.email | Object | Email-specific settings |
+| buildData.pipelineName | String | Name of your pipeline |
+| buildData.jobName | String | Job this email is being sent for |
+| buildData.buildId | Number | Build number this email is being sent for |
+| buildData.buildLink | String | Link to build |
+
+buildData.settings.email can take either:
+
+#### Simple Config
+
+```js
+buildData.settings.email = 'notify.me@email.com'
+```
+
+#### Advanced Config
+
+```js
+buildData.settings.email = {
+    addresses: ['notify.me@email.com', 'notify.you@email.com'], // Multiple recipient addresses
+    statuses: ['SUCCESS', 'FAILURE'] // Build statuses to notify addresses about
+}
+```
 
 ## Testing
 
@@ -25,7 +65,7 @@ Code licensed under the BSD 3-Clause license. See LICENSE file for terms.
 [license-image]: https://img.shields.io/npm/l/screwdriver-notifications-email.svg
 [issues-image]: https://img.shields.io/github/issues/screwdriver-cd/notifications-email.svg
 [issues-url]: https://github.com/screwdriver-cd/notifications-email/issues
-[status-image]: https://cd.screwdriver.cd/pipelines/pipelineid/badge
-[status-url]: https://cd.screwdriver.cd/pipelines/pipelineid
+[status-image]: https://cd.screwdriver.cd/pipelines/89/badge
+[status-url]: https://cd.screwdriver.cd/pipelines/89
 [daviddm-image]: https://david-dm.org/screwdriver-cd/notifications-email.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/screwdriver-cd/notifications-email

--- a/email.js
+++ b/email.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const nodemailer = require('nodemailer');
+
+/**
+* Sends email message
+* @param {object} mailOpts                keys described below
+* @param {string} mailOpts.from           sender email address (must be compatible with smtp)
+* @param {(string|string[])} mailOpts.to  recipient(s) of email
+* @param {string} mailOpts.subject        subject of email
+* @param {string} mailOpts.text           plain text body of email
+* @param {string} mailOpts.html           html body of email
+* @param {object} smtpConfig              keys described below
+* @param {string} smtpConfig.host         smtp server host url
+* @param {number} smtpConfig.port         smtp host port (e.g. 25)
+* @return {Promise}                       resolves if email is sent
+*/
+module.exports = (mailOpts, smtpConfig) => {
+    const transporter = nodemailer.createTransport(smtpConfig);
+
+    return new Promise((resolve, reject) => {
+        transporter.sendMail(mailOpts, (error) => {
+            if (error) {
+                return reject(error);
+            }
+
+            return resolve();
+        });
+    });
+};

--- a/index.js
+++ b/index.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const Joi = require('joi');
+const emailer = require('./email');
+
+const DESCRIPTION_MAP = {
+    SUCCESS: 'Everything looks good!',
+    FAILURE: 'Did not work as expected.',
+    ABORTED: 'Aborted mid-flight',
+    RUNNING: 'Testing your code...',
+    QUEUED: 'Looking for a place to park...'
+};
+const DEFAULT_STATUSES = ['FAILURE'];
+// Joi Schema Validation
+const SCHEMA_ADDRESS = Joi.string().email();
+const SCHEMA_ADDRESSES = Joi.array()
+    .items(SCHEMA_ADDRESS)
+    .min(0);
+const SCHEMA_STATUS = Joi.string().valid(Object.keys(DESCRIPTION_MAP));
+const SCHEMA_STATUSES = Joi.array()
+    .items(SCHEMA_STATUS)
+    .min(0);
+const SCHEMA_EMAIL = Joi.alternatives().try(
+    Joi.object().keys({ addresses: SCHEMA_ADDRESSES, statuses: SCHEMA_STATUSES }),
+    SCHEMA_ADDRESS, SCHEMA_ADDRESSES
+    );
+const SCHEMA_BUILD_SETTINGS = Joi.object()
+    .keys({
+        email: SCHEMA_EMAIL
+    }).unknown(true);
+const SCHEMA_BUILD_DATA = Joi.object()
+    .keys({
+        settings: SCHEMA_BUILD_SETTINGS.required(),
+        status: SCHEMA_STATUS.required(),
+        pipelineName: Joi.string(),
+        jobName: Joi.string(),
+        buildId: Joi.number().integer(),
+        buildLink: Joi.string()
+    });
+const SCHEMA_SMTP_CONFIG = Joi.object()
+    .keys({
+        host: Joi.string().required(),
+        port: Joi.number().integer().required(),
+        from: SCHEMA_ADDRESS.required()
+    });
+
+class EmailNotifier {
+    /**
+    * Constructs an EmailNotifier
+    * @constructor
+    * @param {object} config - Screwdriver config object initialized in API
+    * @param {Hapi.server} server - server initialized in API
+    * @param {string} eventName - name of notification event to listen on
+    */
+    constructor(config, server, eventName) {
+        this.config = Joi.attempt(config, SCHEMA_SMTP_CONFIG,
+            'Invalid config for email notifications');
+        this.server = server;
+        this.eventName = eventName; // The event that notify() will trigger a listener on
+    }
+
+    /**
+    * Sets listener on server event of name 'eventName'
+    * Currently, event is triggered with a build status is updated
+    * @method notify
+    * @return {Promise} resolves to false if status is not in notification statuses
+    *                   resolves to emailer if status is in notification statuses
+    */
+    notify() {
+        return new Promise((resolve, reject) => {
+            this.server.on(this.eventName, (buildData) => {
+                // Check buildData format against SCHEMA_BUILD_DATA
+                try {
+                    Joi.attempt(buildData, SCHEMA_BUILD_DATA, 'Invalid build data format');
+                } catch (e) {
+                    return reject(e);
+                }
+
+                if (typeof buildData.settings.email === 'string' ||
+                    Array.isArray(buildData.settings.email)) {
+                    buildData.settings.email = {
+                        addresses: buildData.settings.email,
+                        statuses: DEFAULT_STATUSES
+                    };
+                }
+
+                if (!buildData.settings.email.statuses.includes(buildData.status)) {
+                    return resolve(null);
+                }
+
+                const subject = `Screwdriver Build ${buildData.pipelineName}` +
+                    `${buildData.jobName} ${buildData.buildId} ${buildData.status}`;
+                const message = `${DESCRIPTION_MAP[buildData.status]} \n${buildData.buildLink}`;
+                const html = `${DESCRIPTION_MAP[buildData.status]} </br>` +
+                    `<a href="${buildData.buildLink}">Link</a> to your build.`;
+
+                const mailOpts = {
+                    from: this.config.from,
+                    to: buildData.settings.email.addresses,
+                    subject,
+                    text: message,
+                    html
+                };
+
+                const smtpConfig = {
+                    host: this.config.host,
+                    port: this.config.port
+                };
+
+                return resolve(emailer(mailOpts, smtpConfig));
+            });
+        });
+    }
+}
+
+module.exports = EmailNotifier;

--- a/package.json
+++ b/package.json
@@ -24,18 +24,26 @@
     "Dao Lam <daolam112@gmail.com>",
     "Darren Matsumoto <aeneascorrupt@gmail.com>",
     "Jeremiah Wuenschel <jeremiah.wuenschel@gmail.com>",
+    "Jerry Zhang <thejerryzhang@gmail.com>",
     "Min Zhang <minzhang@andrew.cmu.edu>",
     "Peter Peterson <jedipetey@gmail.com>",
-    "St. John Johnson <st.john.johnson@gmail.com",
+    "Reetika Rastogi <r3rastogi@gmail.com>",
+    "St. John Johnson <st.john.johnson@gmail.com>",
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "^3.9.1",
     "eslint-config-screwdriver": "^2.0.9",
-    "jenkins-mocha": "^3.0.0"
+    "jenkins-mocha": "^4.1.1",
+    "mockery": "^2.0.0",
+    "hapi": "^16.1.0",
+    "sinon": "^1.17.7"
   },
-  "dependencies": {},
+  "dependencies": {
+    "joi": "^10.2.2",
+    "nodemailer": "^3.1.3"
+  },
   "release": {
     "debug": false,
     "verifyConditions": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,9 +1,348 @@
 'use strict';
 
+const Hapi = require('hapi');
 const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
 
-describe('index test', () => {
-    it('fails', () => {
-        assert.isTrue(false);
+sinon.assert.expose(assert, { prefix: '' });
+
+/**
+ * helper to generate a nodemailer mock
+ * @method getUserMock
+ * @return {Function}         Stubbed function
+ */
+function getNodemailerMock() {
+    const sendMailMock = {
+        sendMail: sinon.stub().yieldsAsync()
+    };
+
+    return { createTransport: sinon.stub().returns(sendMailMock) };
+}
+
+describe('index', () => {
+    let serverMock;
+    let configMock;
+    let notifier;
+    let buildDataMock;
+    let nodemailerMock;
+    let EmailNotifier;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+
+        nodemailerMock = getNodemailerMock();
+        mockery.registerMock('nodemailer', nodemailerMock);
+
+        // eslint-disable-next-line global-require
+        EmailNotifier = require('../index');
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    describe('notifier listens to server emits', () => {
+        beforeEach(() => {
+            nodemailerMock.createTransport.reset();
+
+            serverMock = new Hapi.Server();
+            configMock = {
+                host: 'testing.aserver.com',
+                port: 25,
+                from: 'user@email.com'
+            };
+            buildDataMock = {
+                settings: {
+                    email: {
+                        addresses: ['notify.me@email.com', 'notify.you@email.com'],
+                        statuses: ['SUCCESS', 'FAILURE']
+                    }
+                },
+                status: 'SUCCESS',
+                pipelineName: 'screwdriver-cd/notifications',
+                jobName: 'publish',
+                buildId: '1234',
+                buildLink: 'http://thisisaSDtest.com/builds/1234'
+            };
+            notifier = new EmailNotifier(configMock, serverMock, 'build_status_test');
+        });
+
+        it('verifies that included status creates nodemailer transporter', () => {
+            serverMock.event('build_status_test');
+
+            const saveMe = notifier.notify().then(() => {
+                assert.calledWith(nodemailerMock.createTransport,
+                    { host: configMock.host, port: configMock.port });
+            });
+
+            serverMock.emit('build_status_test', buildDataMock);
+
+            return saveMe;
+        });
+
+        it('verifies that non-included status returns null', () => {
+            const buildDataMockUnincluded = {
+                settings: {
+                    email: {
+                        addresses: ['notify.me@email.com', 'notify.you@email.com'],
+                        statuses: ['SUCCESS', 'FAILURE']
+                    }
+                },
+                status: 'invalid_status'
+            };
+
+            serverMock.event('build_status_test');
+
+            const saveMe = notifier.notify()
+            .then(() => {
+                assert.fail('Should not get here');
+            })
+            .catch((err) => {
+                assert.instanceOf(err, Error);
+                assert.equal(err.name, 'ValidationError');
+            });
+
+            serverMock.emit('build_status_test', buildDataMockUnincluded);
+
+            return saveMe;
+        });
+
+        it('verifies that non-subscribed status does not send a notifcation', () => {
+            const buildDataMockUnincluded = {
+                settings: {
+                    email: {
+                        addresses: ['notify.me@email.com', 'notify.you@email.com'],
+                        statuses: ['SUCCESS', 'FAILURE']
+                    }
+                },
+                status: 'ABORTED'
+            };
+
+            serverMock.event('build_status_test');
+
+            const saveMe = notifier.notify().then((res) => {
+                assert.equal(res, null);
+            });
+
+            serverMock.emit('build_status_test', buildDataMockUnincluded);
+
+            return saveMe;
+        });
+
+        it('sets addresses and statuses for simple email string config settings', () => {
+            const buildDataMockSimple = {
+                settings: {
+                    email: 'notify.me@email.com'
+                },
+                status: 'FAILURE',
+                pipelineName: 'screwdriver-cd/notifications',
+                jobName: 'publish',
+                buildId: '1234',
+                buildLink: 'http://thisisaSDtest.com/builds/1234'
+            };
+
+            serverMock.event('build_status_test');
+
+            const saveMe = notifier.notify().then(() => {
+                assert.calledWith(nodemailerMock.createTransport,
+                    { host: configMock.host, port: configMock.port });
+            });
+
+            serverMock.emit('build_status_test', buildDataMockSimple);
+
+            return saveMe;
+        });
+
+        it('sets addresses and statuses for an array of emails in config settings', () => {
+            const buildDataMockArray = {
+                settings: {
+                    email: ['notify.me@email.com', 'notify.you@email.com']
+                },
+                status: 'FAILURE',
+                pipelineName: 'screwdriver-cd/notifications',
+                jobName: 'publish',
+                buildId: '1234',
+                buildLink: 'http://thisisaSDtest.com/builds/1234'
+            };
+
+            serverMock.event('build_status_test');
+
+            const saveMe = notifier.notify().then(() => {
+                assert.calledWith(nodemailerMock.createTransport,
+                    { host: configMock.host, port: configMock.port });
+            });
+
+            serverMock.emit('build_status_test', buildDataMockArray);
+
+            return saveMe;
+        });
+
+        it('allows additional notifications plugins in buildData.settings', () => {
+            buildDataMock.settings.hipchat = {
+                awesome: 'sauce',
+                catch: 22
+            };
+
+            serverMock.event('build_status_test');
+
+            const saveMe = notifier.notify().then(() => {
+                assert.calledWith(nodemailerMock.createTransport,
+                    { host: configMock.host, port: configMock.port });
+            });
+
+            serverMock.emit('build_status_test', buildDataMock);
+
+            return saveMe;
+        });
+    });
+
+    describe('config and buildData are validated', () => {
+        beforeEach(() => {
+            nodemailerMock.createTransport.reset();
+
+            serverMock = new Hapi.Server();
+            configMock = {
+                host: 'testing.aserver.com',
+                port: 25,
+                from: 'user@email.com'
+            };
+            buildDataMock = {
+                settings: {
+                    email: {
+                        addresses: ['notify.me@email.com', 'notify.you@email.com'],
+                        statuses: ['SUCCESS', 'FAILURE']
+                    }
+                },
+                status: 'SUCCESS',
+                pipelineName: 'screwdriver-cd/notifications',
+                jobName: 'publish',
+                buildId: '1234',
+                buildLink: 'http://thisisaSDtest.com/builds/1234'
+            };
+        });
+
+        it('validates host', () => {
+            configMock.host = 22;
+            try {
+                notifier = new EmailNotifier(configMock, serverMock, 'build_status_test');
+                assert.fail('should not get here');
+            } catch (err) {
+                assert.instanceOf(err, Error);
+                assert.equal(err.name, 'ValidationError');
+            }
+        });
+
+        it('validates port', () => {
+            configMock.port = 'nonIntegerPort';
+            try {
+                notifier = new EmailNotifier(configMock, serverMock, 'build_status_test');
+                assert.fail('should not get here');
+            } catch (err) {
+                assert.instanceOf(err, Error);
+                assert.equal(err.name, 'ValidationError');
+            }
+        });
+
+        it('validates the from email', () => {
+            configMock.from = 'nonEmailString';
+            try {
+                notifier = new EmailNotifier(configMock, serverMock, 'build_status_test');
+                assert.fail('should not get here');
+            } catch (err) {
+                assert.instanceOf(err, Error);
+                assert.equal(err.name, 'ValidationError');
+            }
+        });
+
+        it('validates config format', () => {
+            configMock = ['this', 'is', 'wrong'];
+
+            try {
+                notifier = new EmailNotifier(configMock, serverMock, 'build_status_test');
+                assert.fail('should not get here');
+            } catch (err) {
+                assert.instanceOf(err, Error);
+                assert.equal(err.name, 'ValidationError');
+            }
+        });
+    });
+
+    describe('buildData is validated', () => {
+        beforeEach(() => {
+            nodemailerMock.createTransport.reset();
+
+            serverMock = new Hapi.Server();
+            configMock = {
+                host: 'testing.aserver.com',
+                port: 25,
+                from: 'user@email.com'
+            };
+            buildDataMock = {
+                settings: {
+                    email: {
+                        addresses: ['notify.me@email.com', 'notify.you@email.com'],
+                        statuses: ['SUCCESS', 'FAILURE']
+                    }
+                },
+                status: 'SUCCESS',
+                pipelineName: 'screwdriver-cd/notifications',
+                jobName: 'publish',
+                buildId: '1234',
+                buildLink: 'http://thisisaSDtest.com/builds/1234'
+            };
+
+            notifier = new EmailNotifier(configMock, serverMock, 'build_status_test');
+        });
+
+        it('validates status', () => {
+            buildDataMock.status = 22;
+            serverMock.event('build_status_test');
+
+            const saveMe = notifier.notify().then(() => {
+                assert.fail('should not get here');
+            }, (err) => {
+                assert.instanceOf(err, Error);
+                assert.equal(err.name, 'ValidationError');
+            });
+
+            serverMock.emit('build_status_test', buildDataMock);
+
+            return saveMe;
+        });
+
+        it('validates settings', () => {
+            buildDataMock.settings = ['hello@world.com', 'goodbye@universe.com'];
+            serverMock.event('build_status_test');
+            const saveMe = notifier.notify().then(() => {
+                assert.fail('should not get here');
+            }, (err) => {
+                assert.instanceOf(err, Error);
+                assert.equal(err.name, 'ValidationError');
+            });
+
+            serverMock.emit('build_status_test', buildDataMock);
+
+            return saveMe;
+        });
+
+        it('validates buildData format', () => {
+            const buildDataMockInvalid = ['this', 'is', 'wrong'];
+
+            serverMock.event('build_status_test');
+            const saveMe = notifier.notify().then(() => {
+                assert.fail('should not get here');
+            }, (err) => {
+                assert.instanceOf(err, Error);
+                assert.equal(err.name, 'ValidationError');
+            });
+
+            serverMock.emit('build_status_test', buildDataMockInvalid);
+
+            return saveMe;
+        });
     });
 });


### PR DESCRIPTION
This module allows users to send email notifications upon certain build
events. In their cluster setup (through the Screwdriver API), users can
specify an SMTP host and port, as well as events to subscribe to. When
these events occur (for example, a build success or failure), email
notifications will be sent out to users as described in the
`screwdriver.yaml`s of specific projects.

Co-authored between @jerryzhang222 and @r3rastogi
Related to https://github.com/screwdriver-cd/screwdriver/issues/465