### PR TITLE
fix(517): no promise and use notifications-base

### DIFF
--- a/email.js
+++ b/email.js
@@ -13,18 +13,14 @@ const nodemailer = require('nodemailer');
 * @param {object} smtpConfig              keys described below
 * @param {string} smtpConfig.host         smtp server host url
 * @param {number} smtpConfig.port         smtp host port (e.g. 25)
-* @return {Promise}                       resolves if email is sent
 */
 module.exports = (mailOpts, smtpConfig) => {
     const transporter = nodemailer.createTransport(smtpConfig);
 
-    return new Promise((resolve, reject) => {
-        transporter.sendMail(mailOpts, (error) => {
-            if (error) {
-                return reject(error);
-            }
-
-            return resolve();
-        });
+    transporter.sendMail(mailOpts, (error) => {
+        if (error) {
+            // eslint-disable-next-line no-console
+            console.error(error);
+        }
     });
 };

--- a/index.js
+++ b/index.js
@@ -108,8 +108,7 @@ class EmailNotifier extends NotificationBase {
             port: this.config.port
         };
 
-        // eslint-disable-next-line no-new
-        new Promise(resolve => resolve(emailer(mailOpts, smtpConfig)));
+        emailer(mailOpts, smtpConfig);
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -108,7 +108,8 @@ class EmailNotifier extends NotificationBase {
             port: this.config.port
         };
 
-        emailer(mailOpts, smtpConfig);
+        // eslint-disable-next-line no-new
+        new Promise(resolve => resolve(emailer(mailOpts, smtpConfig)));
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const NotificationBase = require('screwdriver-notifications-base');
 const Joi = require('joi');
 const emailer = require('./email');
 const tinytim = require('tinytim');
@@ -28,7 +29,7 @@ const SCHEMA_EMAIL = Joi.alternatives().try(
     );
 const SCHEMA_BUILD_SETTINGS = Joi.object()
     .keys({
-        email: SCHEMA_EMAIL
+        email: SCHEMA_EMAIL.required()
     }).unknown(true);
 const SCHEMA_BUILD_DATA = Joi.object()
     .keys({
@@ -46,19 +47,16 @@ const SCHEMA_SMTP_CONFIG = Joi.object()
         from: SCHEMA_ADDRESS.required()
     });
 
-class EmailNotifier {
+class EmailNotifier extends NotificationBase {
     /**
     * Constructs an EmailNotifier
     * @constructor
     * @param {object} config - Screwdriver config object initialized in API
-    * @param {Hapi.server} server - server initialized in API
-    * @param {string} eventName - name of notification event to listen on
     */
-    constructor(config, server, eventName) {
+    constructor(config) {
+        super(...arguments);
         this.config = Joi.attempt(config, SCHEMA_SMTP_CONFIG,
             'Invalid config for email notifications');
-        this.server = server;
-        this.eventName = eventName; // The event that notify() will trigger a listener on
     }
 
     /**
@@ -68,55 +66,50 @@ class EmailNotifier {
     * @return {Promise} resolves to false if status is not in notification statuses
     *                   resolves to emailer if status is in notification statuses
     */
-    notify() {
-        return new Promise((resolve, reject) => {
-            this.server.on(this.eventName, (buildData) => {
-                // Check buildData format against SCHEMA_BUILD_DATA
-                try {
-                    Joi.attempt(buildData, SCHEMA_BUILD_DATA, 'Invalid build data format');
-                } catch (e) {
-                    return reject(e);
-                }
-
-                if (typeof buildData.settings.email === 'string' ||
-                    Array.isArray(buildData.settings.email)) {
-                    buildData.settings.email = {
-                        addresses: buildData.settings.email,
-                        statuses: DEFAULT_STATUSES
-                    };
-                }
-
-                if (!buildData.settings.email.statuses.includes(buildData.status)) {
-                    return resolve(null);
-                }
-
-                const subject = `${buildData.status} - Screwdriver ${buildData.pipelineName} ` +
-                    `${buildData.jobName} #${buildData.buildId}`;
-                const message = `Build status: ${buildData.status}` +
-                    `\nBuild link:${buildData.buildLink}`;
-                const html = tinytim.renderFile(path.resolve(__dirname, './template/email.html'), {
-                    buildStatus: buildData.status,
-                    buildLink: buildData.buildLink,
-                    buildId: buildData.buildId,
-                    statusColor: COLOR_MAP[buildData.status]
-                });
-
-                const mailOpts = {
-                    from: this.config.from,
-                    to: buildData.settings.email.addresses,
-                    subject,
-                    text: message,
-                    html
+    _notify(buildData) {
+        // Check buildData format against SCHEMA_BUILD_DATA
+        try {
+            Joi.attempt(buildData, SCHEMA_BUILD_DATA, 'Invalid build data format');
+            if (typeof buildData.settings.email === 'string' ||
+                Array.isArray(buildData.settings.email)) {
+                buildData.settings.email = {
+                    addresses: buildData.settings.email,
+                    statuses: DEFAULT_STATUSES
                 };
+            }
 
-                const smtpConfig = {
-                    host: this.config.host,
-                    port: this.config.port
-                };
+            if (!buildData.settings.email.statuses.includes(buildData.status)) {
+                return;
+            }
 
-                return resolve(emailer(mailOpts, smtpConfig));
+            const subject = `${buildData.status} - Screwdriver ${buildData.pipelineName} ` +
+                `${buildData.jobName} #${buildData.buildId}`;
+            const message = `Build status: ${buildData.status}` +
+                `\nBuild link:${buildData.buildLink}`;
+            const html = tinytim.renderFile(path.resolve(__dirname, './template/email.html'), {
+                buildStatus: buildData.status,
+                buildLink: buildData.buildLink,
+                buildId: buildData.buildId,
+                statusColor: COLOR_MAP[buildData.status]
             });
-        });
+
+            const mailOpts = {
+                from: this.config.from,
+                to: buildData.settings.email.addresses,
+                subject,
+                text: message,
+                html
+            };
+
+            const smtpConfig = {
+                host: this.config.host,
+                port: this.config.port
+            };
+
+            emailer(mailOpts, smtpConfig);
+        } catch (e) {
+            // to not throw Error in event handler
+        }
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -70,46 +70,46 @@ class EmailNotifier extends NotificationBase {
         // Check buildData format against SCHEMA_BUILD_DATA
         try {
             Joi.attempt(buildData, SCHEMA_BUILD_DATA, 'Invalid build data format');
-            if (typeof buildData.settings.email === 'string' ||
-                Array.isArray(buildData.settings.email)) {
-                buildData.settings.email = {
-                    addresses: buildData.settings.email,
-                    statuses: DEFAULT_STATUSES
-                };
-            }
-
-            if (!buildData.settings.email.statuses.includes(buildData.status)) {
-                return;
-            }
-
-            const subject = `${buildData.status} - Screwdriver ${buildData.pipelineName} ` +
-                `${buildData.jobName} #${buildData.buildId}`;
-            const message = `Build status: ${buildData.status}` +
-                `\nBuild link:${buildData.buildLink}`;
-            const html = tinytim.renderFile(path.resolve(__dirname, './template/email.html'), {
-                buildStatus: buildData.status,
-                buildLink: buildData.buildLink,
-                buildId: buildData.buildId,
-                statusColor: COLOR_MAP[buildData.status]
-            });
-
-            const mailOpts = {
-                from: this.config.from,
-                to: buildData.settings.email.addresses,
-                subject,
-                text: message,
-                html
-            };
-
-            const smtpConfig = {
-                host: this.config.host,
-                port: this.config.port
-            };
-
-            emailer(mailOpts, smtpConfig);
         } catch (e) {
-            // to not throw Error in event handler
+            return;
         }
+        if (typeof buildData.settings.email === 'string' ||
+            Array.isArray(buildData.settings.email)) {
+            buildData.settings.email = {
+                addresses: buildData.settings.email,
+                statuses: DEFAULT_STATUSES
+            };
+        }
+
+        if (!buildData.settings.email.statuses.includes(buildData.status)) {
+            return;
+        }
+
+        const subject = `${buildData.status} - Screwdriver ${buildData.pipelineName} ` +
+            `${buildData.jobName} #${buildData.buildId}`;
+        const message = `Build status: ${buildData.status}` +
+            `\nBuild link:${buildData.buildLink}`;
+        const html = tinytim.renderFile(path.resolve(__dirname, './template/email.html'), {
+            buildStatus: buildData.status,
+            buildLink: buildData.buildLink,
+            buildId: buildData.buildId,
+            statusColor: COLOR_MAP[buildData.status]
+        });
+
+        const mailOpts = {
+            from: this.config.from,
+            to: buildData.settings.email.addresses,
+            subject,
+            text: message,
+            html
+        };
+
+        const smtpConfig = {
+            host: this.config.host,
+            port: this.config.port
+        };
+
+        emailer(mailOpts, smtpConfig);
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -60,11 +60,10 @@ class EmailNotifier extends NotificationBase {
     }
 
     /**
-    * Sets listener on server event of name 'eventName'
+    * Sets listener on server event of name 'eventName' in Screwdriver
     * Currently, event is triggered with a build status is updated
-    * @method notify
-    * @return {Promise} resolves to false if status is not in notification statuses
-    *                   resolves to emailer if status is in notification statuses
+    * @method _notify
+    * @param {Object} buildData - Build data emitted with some event from Screwdriver
     */
     _notify(buildData) {
         // Check buildData format against SCHEMA_BUILD_DATA

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "joi": "^10.2.2",
     "nodemailer": "^3.1.3",
-    "screwdriver-notifications-base": "^2.0.0",
+    "screwdriver-notifications-base": "^3.0.0",
     "tinytim": "^0.1.1"
   },
   "release": {

--- a/package.json
+++ b/package.json
@@ -35,14 +35,15 @@
     "chai": "^3.5.0",
     "eslint": "^3.9.1",
     "eslint-config-screwdriver": "^2.0.9",
+    "hapi": "^16.1.0",
     "jenkins-mocha": "^4.1.1",
     "mockery": "^2.0.0",
-    "hapi": "^16.1.0",
     "sinon": "^1.17.7"
   },
   "dependencies": {
     "joi": "^10.2.2",
     "nodemailer": "^3.1.3",
+    "screwdriver-notifications-base": "^2.0.0",
     "tinytim": "^0.1.1"
   },
   "release": {


### PR DESCRIPTION
### Context
Notification plugins are registered at [registerPlugins](https://github.com/screwdriver-cd/screwdriver/blob/master/lib/registerPlugins.js#L85) and called `notify`, then notification plugin returns a Promise but `registerPlugins` does not use the status of Promise.

On the other hand, Hapi.js has a bug which throwing inside response event breaks new events ( https://github.com/hapijs/hapi/issues/3464). For example, [this line](https://github.com/screwdriver-cd/notifications-email/blob/master/index.js#L89) throws error when `buildData.settings.email.statuses` does not have `includes` method.

### Object
This PR provides not to use Promise. Also fix to use `screwdriver-notifications-base`.

### Misc.
Related: 
- Issue: https://github.com/screwdriver-cd/screwdriver/issues/517
- https://github.com/screwdriver-cd/notifications-base/pull/3
- https://github.com/screwdriver-cd/screwdriver/pull/521

#### TODO
- [x] https://github.com/screwdriver-cd/notifications-base/pull/3 is merged and specify screwdirver-notification-base verson in this package.json.
- [ ] do some fix based on reviewed and fixed notifications-base.