### PR TITLE
fix: Update nodemailer version since all v3 is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "joi": "^10.2.2",
-    "nodemailer": "^3.1.3",
+    "nodemailer": "^4.6.7",
     "screwdriver-notifications-base": "^3.0.0",
     "tinytim": "^0.1.1"
   },


### PR DESCRIPTION
Previous version 3.1.3: https://www.npmjs.com/package/nodemailer/v/3.1.3