### PR TITLE
fix: Make sure default status is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,11 +19,11 @@ const DEFAULT_STATUSES = ['FAILURE'];
 const SCHEMA_ADDRESS = Joi.string().email();
 const SCHEMA_ADDRESSES = Joi.array()
     .items(SCHEMA_ADDRESS)
-    .min(0);
+    .min(1);
 const SCHEMA_STATUS = Joi.string().valid(Object.keys(COLOR_MAP));
 const SCHEMA_STATUSES = Joi.array()
     .items(SCHEMA_STATUS)
-    .min(0);
+    .min(1);
 const SCHEMA_EMAIL = Joi.alternatives().try(
     Joi.object().keys({ addresses: SCHEMA_ADDRESSES, statuses: SCHEMA_STATUSES }),
     SCHEMA_ADDRESS, SCHEMA_ADDRESSES

--- a/package.json
+++ b/package.json
@@ -33,17 +33,18 @@
   ],
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^3.9.1",
-    "eslint-config-screwdriver": "^2.0.9",
-    "hapi": "^17.0.0",
-    "jenkins-mocha": "^6.0.0",
+    "eslint": "^4.19.1",
+    "eslint-config-screwdriver": "^3.0.1",
+    "@hapi/hapi": "^17.8.5",
+    "jenkins-mocha": "^8.0.0",
     "mockery": "^2.0.0",
-    "sinon": "^1.17.7"
+    "sinon": "^7.4.2"
   },
   "dependencies": {
+    "hoek": "^6.1.3",
     "joi": "^10.2.2",
-    "nodemailer": "^4.6.7",
-    "screwdriver-notifications-base": "^3.0.0",
+    "nodemailer": "^4.7.0",
+    "screwdriver-notifications-base": "^3.0.2",
     "tinytim": "^0.1.1"
   },
   "release": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 const assert = require('chai').assert;
 const mockery = require('mockery');
 const sinon = require('sinon');


### PR DESCRIPTION
## Context

Seeing some errors in API logs:
```
TypeError: Cannot read property 'includes' of undefined
at EmailNotifier._notify (/usr/src/app/node_modules/screwdriver-notifications-email/index.js:96:48)
```
Need to make sure build status object exists. Seems like some users are setting email settings like below, which is not handled correctly by this plugin:
```
settings:
    email:
        addresses: [test@email.com, test2@email.com]
```

## Objective

This PR:
- updates dependencies (jenkins-mocha, hapi, eslint, etc)
- adds default statuses
- pulls in hoek

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
