### PR TITLE
feat(1668): add more information to email notifications

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,6 +121,8 @@ class EmailNotifier extends NotificationBase {
 
                 changedFilesStr += tinytim.tim(li, { contents: file });
             });
+        } else {
+            changedFilesStr = 'There is no changed files.';
         }
 
         const ul = '<ul>{{list}}</ul>';

--- a/index.js
+++ b/index.js
@@ -111,15 +111,38 @@ class EmailNotifier extends NotificationBase {
             return;
         }
 
+        const changedFiles = Hoek.reach(buildData, 'build.meta.commit.changedFiles').split(',');
+
+        let changedFilesStr = '';
+
+        if (changedFiles.length > 0 && changedFiles[0] !== '') {
+            changedFiles.forEach((file) => {
+                const li = '<li>{{contents}}</li>';
+
+                changedFilesStr += tinytim.tim(li, { contents: file });
+            });
+        }
+
+        const ul = '<ul>{{list}}</ul>';
+
+        changedFilesStr = tinytim.tim(ul, { list: changedFilesStr });
+
         const subject = `${buildData.status} - Screwdriver ` +
             `${Hoek.reach(buildData, 'pipeline.scmRepo.name')} ` +
             `${buildData.jobName} #${Hoek.reach(buildData, 'build.id')}`;
         const message = `Build status: ${buildData.status}` +
             `\nBuild link:${buildData.buildLink}`;
+        const commitSha = Hoek.reach(buildData, 'build.meta.build.sha').slice(0, 7);
+        const commitMessage = Hoek.reach(buildData, 'build.meta.commit.message');
+        const commitLink = Hoek.reach(buildData, 'build.meta.commit.url');
         const html = tinytim.renderFile(path.resolve(__dirname, './template/email.html'), {
             buildStatus: buildData.status,
             buildLink: buildData.buildLink,
             buildId: buildData.build.id,
+            changedFiles: changedFilesStr,
+            commitSha,
+            commitMessage,
+            commitLink,
             statusColor: COLOR_MAP[buildData.status]
         });
 

--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ class EmailNotifier extends NotificationBase {
                 changedFilesStr += tinytim.tim(li, { contents: file });
             });
         } else {
-            changedFilesStr = 'There is no changed files.';
+            changedFilesStr = 'There are no changed files.';
         }
 
         const ul = '<ul>{{list}}</ul>';

--- a/template/email.html
+++ b/template/email.html
@@ -272,6 +272,8 @@
                           </tbody>
                         </table>
                         <p><b>Build URL:</b> <a href="{{buildLink}}" target="_blank">{{buildLink}}</a></p>
+                        <p><b>Changed files:</b>{{changedFiles}}</p>
+                        <p><b>Commit:</b>{{commitMessage}}(<a href="{{commitLink}}" target="_blank">{{commitSha}}</a>)</p>
                       </td>
                     </tr>
                   </table>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -73,7 +73,20 @@ describe('index', () => {
                     }
                 },
                 jobName: 'publish',
-                build: { id: '1234' },
+                build: {
+                    id: '1234',
+                    meta: {
+                        build: {
+                            sha: '123abc'
+                        },
+                        commit: {
+                            changedFiles: 'foo.txt,bar,txt',
+                            message: 'update something',
+                            url: `https://ghe.corp.dummy/screwdriver-cd/
+                                notifications/commit/85b159c5457441c9bc9ff1bc9944f4f6bbd1ff89`
+                        }
+                    }
+                },
                 event: {
                     id: '12345',
                     causeMessage: 'Merge pull request #26 from screwdriver-cd/notifications',
@@ -177,7 +190,20 @@ describe('index', () => {
                     scmRepo: { name: 'screwdriver-cd/notifications' }
                 },
                 jobName: 'publish',
-                build: { id: '1234' },
+                build: {
+                    id: '1234',
+                    meta: {
+                        build: {
+                            sha: '123abc'
+                        },
+                        commit: {
+                            changedFiles: 'foo.txt,bar,txt',
+                            message: 'update something',
+                            url: `https://ghe.corp.dummy/screwdriver-cd/
+                                notifications/commit/85b159c5457441c9bc9ff1bc9944f4f6bbd1ff89`
+                        }
+                    }
+                },
                 event: {
                     id: '12345',
                     causeMessage: 'Merge pull request #26 from screwdriver-cd/notifications',
@@ -212,7 +238,20 @@ describe('index', () => {
                     scmRepo: { name: 'screwdriver-cd/notifications' }
                 },
                 jobName: 'publish',
-                build: { id: '1234' },
+                build: {
+                    id: '1234',
+                    meta: {
+                        build: {
+                            sha: '123abc'
+                        },
+                        commit: {
+                            changedFiles: 'foo.txt,bar,txt',
+                            message: 'update something',
+                            url: `https://ghe.corp.dummy/screwdriver-cd/
+                                notifications/commit/85b159c5457441c9bc9ff1bc9944f4f6bbd1ff89`
+                        }
+                    }
+                },
                 event: {
                     id: '12345',
                     causeMessage: 'Merge pull request #26 from screwdriver-cd/notifications',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -179,6 +179,55 @@ describe('index', () => {
             });
         });
 
+        it(`sets addresses and statuses for simple
+                email string config settings with no changed files`, (done) => {
+            const buildDataMockSimple = {
+                settings: {
+                    email: 'notify.me@email.com'
+                },
+                status: 'FAILURE',
+                pipeline: {
+                    id: '123',
+                    scmRepo: { name: 'screwdriver-cd/notifications' }
+                },
+                jobName: 'publish',
+                build: {
+                    id: '1234',
+                    meta: {
+                        build: {
+                            sha: '123abc'
+                        },
+                        commit: {
+                            changedFiles: '',
+                            message: 'update something',
+                            url: `https://ghe.corp.dummy/screwdriver-cd/
+                                notifications/commit/85b159c5457441c9bc9ff1bc9944f4f6bbd1ff89`
+                        }
+                    }
+                },
+                event: {
+                    id: '12345',
+                    causeMessage: 'Merge pull request #26 from screwdriver-cd/notifications',
+                    creator: { username: 'foo' },
+                    commit: {
+                        author: { name: 'foo' },
+                        message: 'fixing a bug'
+                    }
+                },
+                buildLink: 'http://thisisaSDtest.com/builds/1234'
+            };
+
+            serverMock.event(eventMock);
+            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.emit(eventMock, buildDataMockSimple);
+
+            process.nextTick(() => {
+                assert.calledWith(nodemailerMock.createTransport,
+                    { host: configMock.host, port: configMock.port });
+                done();
+            });
+        });
+
         it('sets addresses and statuses for simple email string config settings', (done) => {
             const buildDataMockSimple = {
                 settings: {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Email notifications are too simple that we can't find what happened with at a glance.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR add more information to email notifications.

Added informations
- changed files
- commit message
- commit sha with github link

This is sample that I confirm in my environment.
![5IHpj5dccc8e773f93ee10b6fd36d](https://user-images.githubusercontent.com/32473622/68825005-fff3e580-06db-11ea-884c-5f6f7e54675c.png)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/1668

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
