### PR TITLE
Add missing statuses

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const emailer = require('./email');
 const tinytim = require('tinytim');
 const path = require('path');
 
-// See also COLOR_MAP in Slack Notification. 
+// See also COLOR_MAP in Slack Notification.
 // https://github.com/screwdriver-cd/notifications-slack/blob/master/index.js#L10
 const COLOR_MAP = {
     ABORTED: '767676',

--- a/index.js
+++ b/index.js
@@ -12,9 +12,9 @@ const path = require('path');
 const COLOR_MAP = {
     ABORTED: '767676',
     CREATED: '0B548C',
-    FAILURE: 'FF4000',    
+    FAILURE: 'FF4000',
     QUEUED: '669999',
-    RUNNING: '0F69FF',    
+    RUNNING: '0F69FF',
     SUCCESS: '00CC00',
     BLOCKED: 'CCC',
     UNSTABLE: 'FFD333',

--- a/index.js
+++ b/index.js
@@ -7,12 +7,19 @@ const emailer = require('./email');
 const tinytim = require('tinytim');
 const path = require('path');
 
+// See also COLOR_MAP in Slack Notification. 
+// https://github.com/screwdriver-cd/notifications-slack/blob/master/index.js#L10
 const COLOR_MAP = {
-    SUCCESS: '3D9970',
-    FAILURE: 'FF4136',
     ABORTED: '767676',
-    RUNNING: '7FDBFF',
-    QUEUED: 'FFDC00'
+    CREATED: '0B548C',
+    FAILURE: 'FF4000',    
+    QUEUED: '669999',
+    RUNNING: '0F69FF',    
+    SUCCESS: '00CC00',
+    BLOCKED: 'CCC',
+    UNSTABLE: 'FFD333',
+    COLLAPSED: 'F2F2F2',
+    FROZEN: 'ACD9FF'
 };
 const DEFAULT_STATUSES = ['FAILURE'];
 // Joi Schema Validation


### PR DESCRIPTION
## Context

No email notification for various statuses, e.g. UNSTABLE was not sending email.

## Objective

Add missing statues to email notification.

## References

 https://github.com/screwdriver-cd/screwdriver/issues/1878

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
