### PR TITLE
feat(1958): Upgrade hapi dependencies. BREAKING CHANGE: hapi v19

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const NotificationBase = require('screwdriver-notifications-base');
-const Hoek = require('hoek');
+const Hoek = require('@hapi/hoek');
 const Joi = require('joi');
 const emailer = require('./email');
 const tinytim = require('tinytim');
@@ -27,7 +27,7 @@ const SCHEMA_ADDRESS = Joi.string().email();
 const SCHEMA_ADDRESSES = Joi.array()
     .items(SCHEMA_ADDRESS)
     .min(1);
-const SCHEMA_STATUS = Joi.string().valid(Object.keys(COLOR_MAP));
+const SCHEMA_STATUS = Joi.string().valid(...Object.keys(COLOR_MAP));
 const SCHEMA_STATUSES = Joi.array()
     .items(SCHEMA_STATUS)
     .min(1);

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "screwdriver-notifications-email",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Sends email notifications on certain build events.",
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive",
+    "test": "mocha --recursive",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -32,17 +32,17 @@
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],
   "devDependencies": {
+    "@hapi/hapi": "^20.0.0",
     "chai": "^3.5.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
-    "@hapi/hapi": "^17.8.5",
-    "jenkins-mocha": "^8.0.0",
+    "mocha": "^8.1.2",
     "mockery": "^2.0.0",
     "sinon": "^7.4.2"
   },
   "dependencies": {
-    "hoek": "^6.1.3",
-    "joi": "^10.2.2",
+    "@hapi/hoek": "^9.0.4",
+    "joi": "^17.2.1",
     "nodemailer": "^4.7.0",
     "screwdriver-notifications-base": "^3.0.2",
     "tinytim": "^0.1.1"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:8
+    image: node:12
 
 jobs:
     main:


### PR DESCRIPTION
## Context

Screwdriver hapi.js dependencies are outdated and not supported anymore.

## Objective

This PR majorly upgrades @hapi/joi version and fixes all schema related changes to be compatible with latest @hapi js dependencies.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1958

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
