### PR TITLE
feat(2022): add source dir message

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,6 +160,8 @@ class EmailNotifier extends NotificationBase {
         const commitSha = Hoek.reach(buildData, 'build.meta.build.sha').slice(0, 7);
         const commitMessage = Hoek.reach(buildData, 'build.meta.commit.message');
         const commitLink = Hoek.reach(buildData, 'build.meta.commit.url');
+        const rootDir = Hoek.reach(buildData, 'pipeline.scmRepo.rootDir', { default: false });
+        const rootDirMsg = rootDir ? tinytim.tim('<p><b>Source Directory:</b>{{rootDir}}</p>', { rootDir }) : '';
         const html = tinytim.renderFile(path.resolve(__dirname, './template/email.html'), {
             buildStatus: notificationStatus,
             buildLink: buildData.buildLink,
@@ -168,6 +170,7 @@ class EmailNotifier extends NotificationBase {
             commitSha,
             commitMessage,
             commitLink,
+            rootDirMsg,
             statusColor: COLOR_MAP[buildData.status]
         });
 

--- a/index.js
+++ b/index.js
@@ -152,17 +152,15 @@ class EmailNotifier extends NotificationBase {
 
         changedFilesStr = tinytim.tim(ul, { list: changedFilesStr });
 
+        const rootDir = Hoek.reach(buildData, 'pipeline.scmRepo.rootDir', { default: ''});
         const subject = `${notificationStatus} - Screwdriver ` +
             `${Hoek.reach(buildData, 'pipeline.scmRepo.name')} ` +
-            `${buildData.jobName} #${Hoek.reach(buildData, 'build.id')}`;
+            `${buildData.jobName} ${rootDir} #${Hoek.reach(buildData, 'build.id')}`;
         const message = `Build status: ${notificationStatus}` +
             `\nBuild link:${buildData.buildLink}`;
         const commitSha = Hoek.reach(buildData, 'build.meta.build.sha').slice(0, 7);
         const commitMessage = Hoek.reach(buildData, 'build.meta.commit.message');
         const commitLink = Hoek.reach(buildData, 'build.meta.commit.url');
-        const rootDir = Hoek.reach(buildData, 'pipeline.scmRepo.rootDir', { default: false });
-        const rootDirTmp = '<p><b>Source Directory:</b>{{rootDir}}</p>';
-        const rootDirMsg = rootDir ? tinytim.tim(rootDirTmp, { rootDir }) : '';
         const html = tinytim.renderFile(path.resolve(__dirname, './template/email.html'), {
             buildStatus: notificationStatus,
             buildLink: buildData.buildLink,
@@ -171,7 +169,6 @@ class EmailNotifier extends NotificationBase {
             commitSha,
             commitMessage,
             commitLink,
-            rootDirMsg,
             statusColor: COLOR_MAP[buildData.status]
         });
 

--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ class EmailNotifier extends NotificationBase {
 
         changedFilesStr = tinytim.tim(ul, { list: changedFilesStr });
 
-        const rootDir = Hoek.reach(buildData, 'pipeline.scmRepo.rootDir', { default: ''});
+        const rootDir = Hoek.reach(buildData, 'pipeline.scmRepo.rootDir', { default: '' });
         const subject = `${notificationStatus} - Screwdriver ` +
             `${Hoek.reach(buildData, 'pipeline.scmRepo.name')} ` +
             `${buildData.jobName} ${rootDir} #${Hoek.reach(buildData, 'build.id')}`;

--- a/index.js
+++ b/index.js
@@ -161,7 +161,8 @@ class EmailNotifier extends NotificationBase {
         const commitMessage = Hoek.reach(buildData, 'build.meta.commit.message');
         const commitLink = Hoek.reach(buildData, 'build.meta.commit.url');
         const rootDir = Hoek.reach(buildData, 'pipeline.scmRepo.rootDir', { default: false });
-        const rootDirMsg = rootDir ? tinytim.tim('<p><b>Source Directory:</b>{{rootDir}}</p>', { rootDir }) : '';
+        const rootDirTmp = '<p><b>Source Directory:</b>{{rootDir}}</p>';
+        const rootDirMsg = rootDir ? tinytim.tim(rootDirTmp, { rootDir }) : '';
         const html = tinytim.renderFile(path.resolve(__dirname, './template/email.html'), {
             buildStatus: notificationStatus,
             buildLink: buildData.buildLink,

--- a/template/email.html
+++ b/template/email.html
@@ -274,6 +274,7 @@
                         <p><b>Build URL:</b> <a href="{{buildLink}}" target="_blank">{{buildLink}}</a></p>
                         <p><b>Changed files:</b>{{changedFiles}}</p>
                         <p><b>Commit:</b>{{commitMessage}}(<a href="{{commitLink}}" target="_blank">{{commitSha}}</a>)</p>
+                        {{rootDirMsg}}
                       </td>
                     </tr>
                   </table>

--- a/template/email.html
+++ b/template/email.html
@@ -274,7 +274,6 @@
                         <p><b>Build URL:</b> <a href="{{buildLink}}" target="_blank">{{buildLink}}</a></p>
                         <p><b>Changed files:</b>{{changedFiles}}</p>
                         <p><b>Commit:</b>{{commitMessage}}(<a href="{{commitLink}}" target="_blank">{{commitSha}}</a>)</p>
-                        {{rootDirMsg}}
                       </td>
                     </tr>
                   </table>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -290,6 +290,55 @@ describe('index', () => {
             });
         });
 
+        it('sets addresses, statuses and srcDir for simple email string config', (done) => {
+            const buildDataMockSimple = {
+                settings: {
+                    email: 'notify.me@email.com'
+                },
+                status: 'FAILURE',
+                pipeline: {
+                    id: '123',
+                    scmRepo: { name: 'screwdriver-cd/notifications' },
+                    rootDir: 'mydir'
+                },
+                jobName: 'publish',
+                build: {
+                    id: '1234',
+                    meta: {
+                        build: {
+                            sha: '123abc'
+                        },
+                        commit: {
+                            changedFiles: 'foo.txt,bar,txt',
+                            message: 'update something',
+                            url: `https://ghe.corp.dummy/screwdriver-cd/
+                                notifications/commit/85b159c5457441c9bc9ff1bc9944f4f6bbd1ff89`
+                        }
+                    }
+                },
+                event: {
+                    id: '12345',
+                    causeMessage: 'Merge pull request #26 from screwdriver-cd/notifications',
+                    creator: { username: 'foo' },
+                    commit: {
+                        author: { name: 'foo' },
+                        message: 'fixing a bug'
+                    }
+                },
+                buildLink: 'http://thisisaSDtest.com/builds/1234'
+            };
+
+            serverMock.event(eventMock);
+            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.emit(eventMock, buildDataMockSimple);
+
+            process.nextTick(() => {
+                assert.calledWith(nodemailerMock.createTransport,
+                    { host: configMock.host, port: configMock.port });
+                done();
+            });
+        });
+
         it('sets addresses and statuses for an array of emails in config settings', (done) => {
             const buildDataMockArray = {
                 settings: {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Add feature https://github.com/screwdriver-cd/screwdriver/issues/2022

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Below is example:
<img width="515" alt="Screen_Shot_2020-10-15_at_16_12_56" src="https://user-images.githubusercontent.com/32473622/96089751-3ea0aa00-0f02-11eb-96f2-882edb57909b.png">


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2022
https://github.com/screwdriver-cd/screwdriver/issues/2005

https://github.com/screwdriver-cd/notifications-slack/pull/32

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
