### PR TITLE
[3] fix: require screwdriver-data-schema@20.6.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const NotificationBase = require('screwdriver-notifications-base');
+const schema = require('screwdriver-data-schema');
 const Hoek = require('@hapi/hoek');
 const Joi = require('joi');
 const emailer = require('./email');
@@ -28,9 +29,8 @@ const SCHEMA_ADDRESS = Joi.string().email();
 const SCHEMA_ADDRESSES = Joi.array()
     .items(SCHEMA_ADDRESS)
     .min(1);
-const SCHEMA_STATUS = Joi.string().valid(...Object.keys(COLOR_MAP));
 const SCHEMA_STATUSES = Joi.array()
-    .items(SCHEMA_STATUS)
+    .items(schema.plugins.notifications.schemaStatus)
     .min(1);
 const SCHEMA_EMAIL = Joi.alternatives().try(
     Joi.object().keys({ addresses: SCHEMA_ADDRESSES, statuses: SCHEMA_STATUSES }),
@@ -40,26 +40,10 @@ const SCHEMA_BUILD_SETTINGS = Joi.object()
     .keys({
         email: SCHEMA_EMAIL.required()
     }).unknown(true);
-const SCHEMA_SCM_REPO = Joi.object()
-    .keys({
-        name: Joi.string().required()
-    }).unknown(true);
-const SCHEMA_PIPELINE_DATA = Joi.object()
-    .keys({
-        scmRepo: SCHEMA_SCM_REPO.required()
-    }).unknown(true);
 const SCHEMA_BUILD_DATA = Joi.object()
     .keys({
-        settings: SCHEMA_BUILD_SETTINGS.required(),
-        status: SCHEMA_STATUS.required(),
-        pipeline: SCHEMA_PIPELINE_DATA.required(),
-        jobName: Joi.string(),
-        build: Joi.object().keys({
-            id: Joi.number().integer().required()
-        }).unknown(true),
-        event: Joi.object(),
-        buildLink: Joi.string(),
-        isFixed: Joi.boolean()
+        ...schema.plugins.notifications.schemaBuildData,
+        settings: SCHEMA_BUILD_SETTINGS.required()
     });
 const SCHEMA_SMTP_CONFIG = Joi.object()
     .keys({

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@hapi/hoek": "^9.0.4",
     "joi": "^17.2.1",
     "nodemailer": "^4.7.0",
+    "screwdriver-data-schema": "^20.6.0",
     "screwdriver-notifications-base": "^3.0.2",
     "tinytim": "^0.1.1"
   },


### PR DESCRIPTION
## Context
The same definitions exist for both [notification-email](https://github.com/screwdriver-cd/notifications-email/blob/e9906f2601e50cddaf21e80b877992d01332ac34/index.js#L54-L62) and [notification-slack](https://github.com/screwdriver-cd/notifications-slack/blob/59f18306297795c4288591f562a552396ccacd72/index.js#L66-L74), and it is possible that the next time we add a feature, we will miss a fix for one or the other.

## Objective
The definitions that exist in both [notification-email](https://github.com/screwdriver-cd/notifications-email/blob/e9906f2601e50cddaf21e80b877992d01332ac34/index.js#L54-L62) and [notification-slack](https://github.com/screwdriver-cd/notifications-slack/blob/59f18306297795c4288591f562a552396ccacd72/index.js#L66-L74) are combined in one place.

Merging https://github.com/screwdriver-cd/data-schema/pull/420 will create the screwdriver-data-schema@20.6.0 package.

## References
[1] https://github.com/screwdriver-cd/data-schema/pull/420
[2] https://github.com/screwdriver-cd/notifications-slack/pull/33
[3] https://github.com/screwdriver-cd/notifications-email/pull/25 (this PR require [1])

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
