### PR TITLE
[2] fix(2051): fix function that does not exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,19 +31,19 @@ const SCHEMA_ADDRESSES = Joi.array()
     .min(1);
 const SCHEMA_STATUSES = Joi.array()
     .items(schema.plugins.notifications.schemaStatus)
-    .min(1);
+    .min(0);
 const SCHEMA_EMAIL = Joi.alternatives().try(
     Joi.object().keys({ addresses: SCHEMA_ADDRESSES, statuses: SCHEMA_STATUSES }),
     SCHEMA_ADDRESS, SCHEMA_ADDRESSES
 );
-const SCHEMA_BUILD_SETTINGS = Joi.object()
+const SCHEMA_EMAIL_SETTINGS = Joi.object()
     .keys({
         email: SCHEMA_EMAIL.required()
     }).unknown(true);
 const SCHEMA_BUILD_DATA = Joi.object()
     .keys({
         ...schema.plugins.notifications.schemaBuildData,
-        settings: SCHEMA_BUILD_SETTINGS.required()
+        settings: SCHEMA_EMAIL_SETTINGS.required()
     });
 const SCHEMA_SMTP_CONFIG = Joi.object()
     .keys({
@@ -181,7 +181,7 @@ class EmailNotifier extends NotificationBase {
 
     // Validate the settings email object
     static validateConfig(config) {
-        return SCHEMA_EMAIL.validate(config);
+        return SCHEMA_EMAIL_SETTINGS.validate(config);
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ class EmailNotifier extends NotificationBase {
 
     // Validate the settings email object
     static validateConfig(config) {
-        return Joi.validate(config, SCHEMA_EMAIL);
+        return SCHEMA_EMAIL.validate(config);
     }
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -513,24 +513,96 @@ describe('index', () => {
             }
         });
 
-        it('validates normal config format with function', () => {
+        it('is valid config with complete parameters', () => {
             configMock = {
-                addresses: ['notify.me@email.com', 'notify.you@email.com'],
-                statuses: ['SUCCESS', 'FAILURE']
+                email: {
+                    addresses: ['notify.me@email.com', 'notify.you@email.com'],
+                    statuses: ['SUCCESS', 'FAILURE']
+                }
             };
 
             const res = EmailNotifier.validateConfig(configMock);
 
-            assert.isOk(res.value);
+            assert.isUndefined(res.error);
         });
 
-        it('validates abnormal config format with function', () => {
-            configMock = ['this', 'is', 'wrong'];
+        it('is valid config with empty statuses', () => {
+            configMock = {
+                email: {
+                    addresses: ['notify.me@email.com', 'notify.you@email.com'],
+                    statuses: []
+                }
+            };
 
-            const res = EmailNotifier.validateConfig(configMock);
+            const { error } = EmailNotifier.validateConfig(configMock);
 
-            assert.isNotOk(res.value);
-            assert.equal(res.error.message, '"[0]" must be a valid email');
+            assert.isUndefined(error);
+        });
+
+        it('is valid config with addresses', () => {
+            configMock = {
+                email: {
+                    addresses: ['notify.me@email.com', 'notify.you@email.com']
+                }
+            };
+
+            const { error } = EmailNotifier.validateConfig(configMock);
+
+            assert.isUndefined(error);
+        });
+
+        it('is invalid config with empty parameters', () => {
+            configMock = {};
+            const { error } = EmailNotifier.validateConfig(configMock);
+
+            assert.instanceOf(error, Error);
+            assert.equal(error.name, 'ValidationError');
+        });
+
+        it('valid config with empty email settings', () => {
+            configMock = {
+                email: {}
+            };
+            const { error } = EmailNotifier.validateConfig(configMock);
+
+            assert.isUndefined(error);
+        });
+
+        it('valid config without addresses', () => {
+            configMock = {
+                email: {
+                    statuses: ['SUCCESS', 'FAILURE']
+                }
+            };
+            const { error } = EmailNotifier.validateConfig(configMock);
+
+            assert.isUndefined(error);
+        });
+
+        it('invalid config with empty addresses', () => {
+            configMock = {
+                email: {
+                    addresses: [],
+                    statuses: ['SUCCESS', 'FAILURE']
+                }
+            };
+            const { error } = EmailNotifier.validateConfig(configMock);
+
+            assert.instanceOf(error, Error);
+            assert.equal(error.name, 'ValidationError');
+        });
+
+        it('invalid unknown status', () => {
+            configMock = {
+                email: {
+                    addresses: ['notify.me@email.com'],
+                    statuses: ['DUMMY_STATUS']
+                }
+            };
+            const { error } = EmailNotifier.validateConfig(configMock);
+
+            assert.instanceOf(error, Error);
+            assert.equal(error.name, 'ValidationError');
         });
     });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -512,6 +512,26 @@ describe('index', () => {
                 assert.equal(err.name, 'ValidationError');
             }
         });
+
+        it('validates normal config format with function', () => {
+            configMock = {
+                addresses: ['notify.me@email.com', 'notify.you@email.com'],
+                statuses: ['SUCCESS', 'FAILURE']
+            };
+
+            const res = EmailNotifier.validateConfig(configMock);
+
+            assert.isOk(res.value);
+        });
+
+        it('validates abnormal config format with function', () => {
+            configMock = ['this', 'is', 'wrong'];
+
+            const res = EmailNotifier.validateConfig(configMock);
+
+            assert.isNotOk(res.value);
+            assert.equal(res.error.message, '"[0]" must be a valid email');
+        });
     });
 
     describe('buildData is validated', () => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
`Joi.validate` [is not exist](https://github.com/sideway/joi/issues/1941) today.
```
TypeError: Joi.validate is not a function
```

We shold use [schema.validate()](https://github.com/sideway/joi/issues/2145#issuecomment-568173652) instead.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR enables `validateConfig` function by fixing `joi.validate`.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2051

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
