### PR TITLE
feat(2719): Scheduled job stop with notification if there's no admin

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,7 +190,7 @@ function buildStatus(buildData, config) {
  * @param  {String}         jobData.pipelineLink       Pipeline link
  * @param  {String}         jobData.message            Message
  * @param  {Object}         jobData.settings           Notification setting
- * @param  {Object}         config                       Email notifications config
+ * @param  {Object}         config                     Email notifications config
  */
 function jobStatus(jobData, config) {
     try {
@@ -271,7 +271,7 @@ class EmailNotifier extends NotificationBase {
                 buildStatus(payload, this.config);
                 break;
             case 'job_status':
-                jobStatus(payload);
+                jobStatus(payload, this.config);
                 break;
             default:
         }

--- a/package.json
+++ b/package.json
@@ -5,12 +5,11 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 10000 --retries 1 --exit --allow-uncaught true --color true",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 10000 --retries 1 --exit --allow-uncaught true --color true"
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:screwdriver-cd/notifications-email.git"
+    "url": "git+https://github.com/screwdriver-cd/notifications-email.git"
   },
   "homepage": "https://github.com/screwdriver-cd/notifications-email",
   "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",
@@ -49,13 +48,10 @@
     "nodemailer": "^6.4.16",
     "screwdriver-data-schema": "^21.0.0",
     "screwdriver-logger": "^1.1.0",
-    "screwdriver-notifications-base": "^3.0.2",
+    "screwdriver-notifications-base": "^3.2.0",
     "tinytim": "^0.1.1"
   },
   "release": {
-    "debug": false,
-    "verifyConditions": {
-      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
-    }
+    "debug": false
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -769,7 +769,7 @@ describe('index', () => {
             });
         });
 
-        it('validates buildData format', done => {
+        it('validates jobData format', done => {
             const jobDataMockInvalid = ['this', 'is', 'wrong'];
 
             serverMock.event(eventMock);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,28 +7,20 @@ const sinon = require('sinon');
 
 sinon.assert.expose(assert, { prefix: '' });
 
-/**
- * helper to generate a nodemailer mock
- * @method getUserMock
- * @return {Function}         Stubbed function
- */
-function getNodemailerMock() {
+describe('index', () => {
     const sendMailMock = {
         sendMail: sinon.stub().yieldsAsync()
     };
-
-    return { createTransport: sinon.stub().returns(sendMailMock) };
-}
-
-describe('index', () => {
-    const eventMock = 'build_status_test';
-
+    const nodemailerMock = {
+        createTransport: sinon.stub().returns(sendMailMock)
+    };
     let serverMock;
     let configMock;
     let notifier;
     let buildDataMock;
-    let nodemailerMock;
+    let jobDataMock;
     let EmailNotifier;
+    let eventMock;
 
     before(() => {
         mockery.enable({
@@ -36,7 +28,6 @@ describe('index', () => {
             warnOnUnregistered: false
         });
 
-        nodemailerMock = getNodemailerMock();
         mockery.registerMock('nodemailer', nodemailerMock);
 
         // eslint-disable-next-line global-require
@@ -50,6 +41,7 @@ describe('index', () => {
     describe('notifier listens to server emits', () => {
         beforeEach(() => {
             nodemailerMock.createTransport.reset();
+            nodemailerMock.createTransport.returns(sendMailMock);
 
             serverMock = new Hapi.Server();
             configMock = {
@@ -99,12 +91,13 @@ describe('index', () => {
                 buildLink: 'http://thisisaSDtest.com/builds/1234',
                 isFixed: false
             };
-            notifier = new EmailNotifier(configMock, serverMock, 'build_status_test');
+            notifier = new EmailNotifier(configMock, serverMock, 'build_status');
+            eventMock = 'build_status';
         });
 
         it('verifies that included status creates nodemailer transporter', done => {
             serverMock.event(eventMock);
-            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.on(eventMock, data => notifier.notify(eventMock, data));
             serverMock.events.emit(eventMock, buildDataMock);
 
             process.nextTick(() => {
@@ -115,7 +108,7 @@ describe('index', () => {
 
         it('when the build status is fixed, Overwrites the notification status title', done => {
             serverMock.event(eventMock);
-            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.on(eventMock, data => notifier.notify(eventMock, data));
             serverMock.events.emit(eventMock, buildDataMock);
             buildDataMock.isFixed = true;
 
@@ -129,10 +122,10 @@ describe('index', () => {
             configMock.username = 'batman';
             configMock.password = 'robin';
 
-            notifier = new EmailNotifier(configMock, serverMock, 'build_status_test');
+            notifier = new EmailNotifier(configMock, serverMock, 'build_status');
 
             serverMock.event(eventMock);
-            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.on(eventMock, data => notifier.notify(eventMock, data));
             serverMock.events.emit(eventMock, buildDataMock);
 
             process.nextTick(() => {
@@ -160,7 +153,7 @@ describe('index', () => {
             };
 
             serverMock.event(eventMock);
-            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.on(eventMock, data => notifier.notify(eventMock, data));
             serverMock.events.emit(eventMock, buildDataMockUnincluded);
 
             process.nextTick(() => {
@@ -181,7 +174,7 @@ describe('index', () => {
             };
 
             serverMock.event(eventMock);
-            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.on(eventMock, data => notifier.notify(eventMock, data));
             serverMock.events.emit(eventMock, buildDataMockUnincluded);
 
             process.nextTick(() => {
@@ -229,7 +222,7 @@ describe('index', () => {
             };
 
             serverMock.event(eventMock);
-            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.on(eventMock, data => notifier.notify(eventMock, data));
             serverMock.events.emit(eventMock, buildDataMockSimple);
 
             process.nextTick(() => {
@@ -276,7 +269,7 @@ describe('index', () => {
             };
 
             serverMock.event(eventMock);
-            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.on(eventMock, data => notifier.notify(eventMock, data));
             serverMock.events.emit(eventMock, buildDataMockSimple);
 
             process.nextTick(() => {
@@ -324,7 +317,7 @@ describe('index', () => {
             };
 
             serverMock.event(eventMock);
-            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.on(eventMock, data => notifier.notify(eventMock, data));
             serverMock.events.emit(eventMock, buildDataMockSimple);
 
             process.nextTick(() => {
@@ -371,7 +364,7 @@ describe('index', () => {
             };
 
             serverMock.event(eventMock);
-            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.on(eventMock, data => notifier.notify(eventMock, data));
             serverMock.events.emit(eventMock, buildDataMockArray);
 
             process.nextTick(() => {
@@ -387,7 +380,7 @@ describe('index', () => {
             };
 
             serverMock.event(eventMock);
-            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.on(eventMock, data => notifier.notify(eventMock, data));
             serverMock.events.emit(eventMock, buildDataMock);
 
             process.nextTick(() => {
@@ -400,6 +393,7 @@ describe('index', () => {
     describe('config and buildData are validated', () => {
         beforeEach(() => {
             nodemailerMock.createTransport.reset();
+            nodemailerMock.createTransport.returns(sendMailMock);
 
             serverMock = new Hapi.Server();
             configMock = {
@@ -407,41 +401,12 @@ describe('index', () => {
                 port: 25,
                 from: 'user@email.com'
             };
-            buildDataMock = {
-                settings: {
-                    email: {
-                        addresses: ['notify.me@email.com', 'notify.you@email.com'],
-                        statuses: ['SUCCESS', 'FAILURE']
-                    }
-                },
-                status: 'SUCCESS',
-                pipeline: {
-                    id: '123',
-                    scmRepo: {
-                        name: 'screwdriver-cd/notifications'
-                    }
-                },
-                jobName: 'publish',
-                build: {
-                    id: '1234'
-                },
-                event: {
-                    id: '12345',
-                    causeMessage: 'Merge pull request #26 from screwdriver-cd/notifications',
-                    creator: { username: 'foo' },
-                    commit: {
-                        author: { name: 'foo' },
-                        message: 'fixing a bug'
-                    }
-                },
-                buildLink: 'http://thisisaSDtest.com/builds/1234'
-            };
         });
 
         it('validates host', () => {
             configMock.host = 22;
             try {
-                notifier = new EmailNotifier(configMock, serverMock, 'build_status_test');
+                notifier = new EmailNotifier(configMock, serverMock, 'build_status');
                 assert.fail('should not get here');
             } catch (err) {
                 assert.instanceOf(err, Error);
@@ -452,7 +417,7 @@ describe('index', () => {
         it('validates port', () => {
             configMock.port = 'nonIntegerPort';
             try {
-                notifier = new EmailNotifier(configMock, serverMock, 'build_status_test');
+                notifier = new EmailNotifier(configMock, serverMock, 'build_status');
                 assert.fail('should not get here');
             } catch (err) {
                 assert.instanceOf(err, Error);
@@ -463,7 +428,7 @@ describe('index', () => {
         it('validates the from email', () => {
             configMock.from = 'nonEmailString';
             try {
-                notifier = new EmailNotifier(configMock, serverMock, 'build_status_test');
+                notifier = new EmailNotifier(configMock, serverMock, 'build_status');
                 assert.fail('should not get here');
             } catch (err) {
                 assert.instanceOf(err, Error);
@@ -474,7 +439,7 @@ describe('index', () => {
         it('validates the username', () => {
             configMock.username = 22;
             try {
-                notifier = new EmailNotifier(configMock, serverMock, 'build_status_test');
+                notifier = new EmailNotifier(configMock, serverMock, 'build_status');
                 assert.fail('should not get here');
             } catch (err) {
                 assert.instanceOf(err, Error);
@@ -485,7 +450,7 @@ describe('index', () => {
         it('validates the password', () => {
             configMock.password = 22;
             try {
-                notifier = new EmailNotifier(configMock, serverMock, 'build_status_test');
+                notifier = new EmailNotifier(configMock, serverMock, 'build_status');
                 assert.fail('should not get here');
             } catch (err) {
                 assert.instanceOf(err, Error);
@@ -497,7 +462,7 @@ describe('index', () => {
             configMock = ['this', 'is', 'wrong'];
 
             try {
-                notifier = new EmailNotifier(configMock, serverMock, 'build_status_test');
+                notifier = new EmailNotifier(configMock, serverMock, 'build_status');
                 assert.fail('should not get here');
             } catch (err) {
                 assert.instanceOf(err, Error);
@@ -601,6 +566,7 @@ describe('index', () => {
     describe('buildData is validated', () => {
         beforeEach(() => {
             nodemailerMock.createTransport.reset();
+            nodemailerMock.createTransport.returns(sendMailMock);
 
             serverMock = new Hapi.Server();
             configMock = {
@@ -638,13 +604,13 @@ describe('index', () => {
                 buildLink: 'http://thisisaSDtest.com/builds/1234'
             };
 
-            notifier = new EmailNotifier(configMock, serverMock, 'build_status_test');
+            notifier = new EmailNotifier(configMock, serverMock, 'build_status');
         });
 
         it('validates status', done => {
             buildDataMock.status = 22;
             serverMock.event(eventMock);
-            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.on(eventMock, data => notifier.notify(eventMock, data));
             serverMock.events.emit(eventMock, buildDataMock);
 
             process.nextTick(() => {
@@ -656,7 +622,7 @@ describe('index', () => {
         it('validates settings', done => {
             buildDataMock.settings = ['hello@world.com', 'goodbye@universe.com'];
             serverMock.event(eventMock);
-            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.on(eventMock, data => notifier.notify(eventMock, data));
             serverMock.events.emit(eventMock, buildDataMock);
 
             process.nextTick(() => {
@@ -669,8 +635,146 @@ describe('index', () => {
             const buildDataMockInvalid = ['this', 'is', 'wrong'];
 
             serverMock.event(eventMock);
-            serverMock.events.on(eventMock, data => notifier.notify(data));
+            serverMock.events.on(eventMock, data => notifier.notify(eventMock, data));
             serverMock.events.emit(eventMock, buildDataMockInvalid);
+
+            process.nextTick(() => {
+                assert.notCalled(nodemailerMock.createTransport);
+                done();
+            });
+        });
+    });
+
+    describe('config and payload for job event are validated', () => {
+        beforeEach(() => {
+            nodemailerMock.createTransport.reset();
+            nodemailerMock.createTransport.returns(sendMailMock);
+
+            serverMock = new Hapi.Server();
+            configMock = {
+                host: 'testing.aserver.com',
+                port: 25,
+                from: 'user@email.com'
+            };
+            jobDataMock = {
+                settings: {
+                    email: {
+                        addresses: ['notify.me@email.com', 'notify.you@email.com'],
+                        statuses: ['SUCCESS', 'FAILURE']
+                    }
+                },
+                status: 'SUCCESS',
+                pipeline: {
+                    id: '123',
+                    scmRepo: {
+                        name: 'screwdriver-cd/notifications'
+                    }
+                },
+                jobName: 'publish',
+                message: 'something went wrong',
+                buildLink: 'http://thisisaSDtest.com/pipeline/1234'
+            };
+            notifier = new EmailNotifier(configMock, serverMock, 'job_status');
+            eventMock = 'job_status';
+        });
+
+        it('validates host', () => {
+            configMock.host = 22;
+            try {
+                notifier = new EmailNotifier(configMock, serverMock, 'job_status');
+                assert.fail('should not get here');
+            } catch (err) {
+                assert.instanceOf(err, Error);
+                assert.equal(err.name, 'ValidationError');
+            }
+        });
+
+        it('validates port', () => {
+            configMock.port = 'nonIntegerPort';
+            try {
+                notifier = new EmailNotifier(configMock, serverMock, 'job_status');
+                assert.fail('should not get here');
+            } catch (err) {
+                assert.instanceOf(err, Error);
+                assert.equal(err.name, 'ValidationError');
+            }
+        });
+
+        it('validates the from email', () => {
+            configMock.from = 'nonEmailString';
+            try {
+                notifier = new EmailNotifier(configMock, serverMock, 'job_status');
+                assert.fail('should not get here');
+            } catch (err) {
+                assert.instanceOf(err, Error);
+                assert.equal(err.name, 'ValidationError');
+            }
+        });
+
+        it('validates the username', () => {
+            configMock.username = 22;
+            try {
+                notifier = new EmailNotifier(configMock, serverMock, 'job_status');
+                assert.fail('should not get here');
+            } catch (err) {
+                assert.instanceOf(err, Error);
+                assert.equal(err.name, 'ValidationError');
+            }
+        });
+
+        it('validates the password', () => {
+            configMock.password = 22;
+            try {
+                notifier = new EmailNotifier(configMock, serverMock, 'job_status');
+                assert.fail('should not get here');
+            } catch (err) {
+                assert.instanceOf(err, Error);
+                assert.equal(err.name, 'ValidationError');
+            }
+        });
+
+        it('validates config format', () => {
+            configMock = ['this', 'is', 'wrong'];
+
+            try {
+                notifier = new EmailNotifier(configMock, serverMock, 'job_status');
+                assert.fail('should not get here');
+            } catch (err) {
+                assert.instanceOf(err, Error);
+                assert.equal(err.name, 'ValidationError');
+            }
+        });
+
+        it('validates status', done => {
+            jobDataMock.status = 22;
+            serverMock.event(eventMock);
+            serverMock.events.on(eventMock, data => notifier.notify(eventMock, data));
+            serverMock.events.emit(eventMock, jobDataMock);
+
+            process.nextTick(() => {
+                assert.notCalled(nodemailerMock.createTransport);
+                done();
+            });
+        });
+
+        it('validates settings', done => {
+            jobDataMock.settings = ['hello@world.com', 'goodbye@universe.com'];
+            serverMock.event(eventMock);
+            serverMock.events.on(eventMock, data => notifier.notify(eventMock, data));
+            serverMock.events.emit(eventMock, jobDataMock);
+
+            process.nextTick(() => {
+                assert.notCalled(nodemailerMock.createTransport);
+                done();
+            });
+        });
+
+        it('validates buildData format', done => {
+            const jobDataMockInvalid = ['this', 'is', 'wrong'];
+
+            serverMock.event(eventMock);
+            serverMock.events.on(eventMock, data => notifier.notify(eventMock, data));
+            serverMock.events.emit(eventMock, jobDataMockInvalid);
 
             process.nextTick(() => {
                 assert.notCalled(nodemailerMock.createTransport);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When scheduled job doesn't run, there's no build nor event for notification plugin to use
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Add ability to notify user with different payload
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2719
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
