### PR TITLE
fix: assign default value for changedFiles

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ function buildStatus(buildData, config) {
         return;
     }
 
-    const changedFiles = Hoek.reach(buildData, 'build.meta.commit.changedFiles', { default : "" }).split(',');
+    const changedFiles = Hoek.reach(buildData, 'build.meta.commit.changedFiles', { default: "" }).split(',');
 
     let changedFilesStr = '';
 

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ function buildStatus(buildData, config) {
         return;
     }
 
-    const changedFiles = Hoek.reach(buildData, 'build.meta.commit.changedFiles', { default: "" }).split(',');
+    const changedFiles = Hoek.reach(buildData, 'build.meta.commit.changedFiles', { default: '' }).split(',');
 
     let changedFilesStr = '';
 

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ function buildStatus(buildData, config) {
         return;
     }
 
-    const changedFiles = Hoek.reach(buildData, 'build.meta.commit.changedFiles', { default : [] }).split(',');
+    const changedFiles = Hoek.reach(buildData, 'build.meta.commit.changedFiles', { default : "" }).split(',');
 
     let changedFilesStr = '';
 

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ function buildStatus(buildData, config) {
         return;
     }
 
-    const changedFiles = Hoek.reach(buildData, 'build.meta.commit.changedFiles').split(',');
+    const changedFiles = Hoek.reach(buildData, 'build.meta.commit.changedFiles', { default : [] }).split(',');
 
     let changedFilesStr = '';
 


### PR DESCRIPTION
## Context

Noticing an error

```
 TypeError: Cannot read properties of undefined (reading 'split')
    at buildStatus (/usr/src/app/node_modules/screwdriver-notifications-email/index.js:116:81)
    at EmailNotifier._notify (/usr/src/app/node_modules/screwdriver-notifications-email/index.js:265:17)
    at EmailNotifier.notify (/usr/src/app/node_modules/screwdriver-notifications-base/index.js:32:18)
    at Object.listener (/usr/src/app/node_modules/screwdriver-api/lib/registerPlugins.js:152:73)
```

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
