### PR TITLE
fix(3464): Email notification content of user controlled input is not being sanitized

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,27 @@ const tinytim = require('tinytim');
 const path = require('path');
 const emailer = require('./email');
 
+/**
+ * Escapes HTML special characters to prevent XSS/HTML injection
+ * @param {String} text - Text to escape
+ * @return {String} - Escaped text safe for HTML
+ */
+function escapeHtml(text) {
+    if (typeof text !== 'string') {
+        return text;
+    }
+
+    const htmlEscapeMap = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#x27;'
+    };
+
+    return text.replace(/[&<>"']/g, char => htmlEscapeMap[char]);
+}
+
 // See also COLOR_MAP in Slack Notification.
 // https://github.com/screwdriver-cd/notifications-slack/blob/master/index.js#L10
 const COLOR_MAP = {
@@ -121,7 +142,7 @@ function buildStatus(buildData, config) {
         changedFiles.forEach(file => {
             const li = '<li>{{contents}}</li>';
 
-            changedFilesStr += tinytim.tim(li, { contents: file });
+            changedFilesStr += tinytim.tim(li, { contents: escapeHtml(file) });
         });
     } else {
         changedFilesStr = 'There are no changed files.';
@@ -146,7 +167,7 @@ function buildStatus(buildData, config) {
         buildId: buildData.build.id,
         changedFiles: changedFilesStr,
         commitSha,
-        commitMessage,
+        commitMessage: escapeHtml(commitMessage),
         commitLink,
         statusColor: COLOR_MAP[buildData.status]
     });


### PR DESCRIPTION
## Context

The `screwdriver-cd/notifications-email` repository is vulnerable to HTML injection. The vulnerability exists because user-controlled input from commit messages and file names is rendered directly into email notifications without proper sanitization. An attacker can leverage this to inject arbitrary HTML, leading to potential phishing attacks or the execution
of malicious JavaScript in the email client.

## Objective

Escape the html content in commit messages and file names.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3464

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
