### PR TITLE
fix: bump nodemailer to reduce vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@hapi/hoek": "^11.0.7",
     "joi": "^17.13.3",
-    "nodemailer": "^7.0.7",
+    "nodemailer": "^9.0.1",
     "screwdriver-data-schema": "^25.0.0",
     "screwdriver-logger": "^3.0.0",
     "screwdriver-notifications-base": "^5.0.0",


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Snyk reports high-severity vulnerabilities in `nodemailer`.

Affected issues:
- https://security.snyk.io/vuln/SNYK-JS-NODEMAILER-17342526
- https://security.snyk.io/vuln/SNYK-JS-NODEMAILER-17375138

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Upgrade `nodemailer` to a non-vulnerable version in `package.json`.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
